### PR TITLE
Fix submodule checkout in data_daily_updating workflow

### DIFF
--- a/.github/workflows/data_daily_updating.yml
+++ b/.github/workflows/data_daily_updating.yml
@@ -32,12 +32,9 @@ jobs:
 
       #### setup submodules __________________________________________________
       - run: |
-          git submodule sync --recursive
-          git submodule update --init --recursive     
-          cd oswm_codebase
-          git fetch origin
-          git reset --hard origin/main
-          cd ..
+          git submodule deinit -f oswm_codebase
+          rm -rf oswm_codebase
+          git submodule add --force --branch main --name oswm_codebase https://github.com/kauevestena/oswm_codebase.git oswm_codebase
 
 
       #### setup-python ________________________________________________________


### PR DESCRIPTION
The data_daily_updating workflow was failing because the oswm_codebase submodule was pointing to a commit that no longer exists in the remote repository.

I modified the workflow to de-initialize and re-initialize the submodule from the remote's main branch, ensuring that the latest version of the submodule is always used.