### PR TITLE
Enable global pedestrian hazard analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,13 @@ cache/
 
 # Routing demo data (deployed as GitHub Pages artifact only, no need for change tracking)
 data/routing/demo.geojson
+data/routing/.*.tmp.*
+
+# Hazard geometry and raster images are generated before Pages deployment.
+# Keep only their compact metadata and API indexes under version control.
+data/hazard_analysis/features_*.geojson
+data/hazard_analysis/terrain_*.png
+data/hazard_analysis/.*.tmp.*
 
 # development stuff
 .vscode

--- a/README.md
+++ b/README.md
@@ -12,16 +12,23 @@ It is a *decentered* and *modular* project, fully GitHub hosted and maintained!
 
 By *decentered* we mean that each city/region is stored in a separate repository, (inspired by https://equalstreetnames.org/ which uses the same concept)
 
-By *modular* we mean that each node has many "apps", each one intended to accomplish a task in the context of management of pedestrian network data, currently we have 4:
+By *modular* we mean that each node has several apps, each intended to
+accomplish a task in pedestrian-network data management:
 
 <!-- TODO: GENERATE AUTOMATICALLY THE DESCRIPTION OF THE MODULES  -->
 
 * Webmap: an interactive cartographic representation of the data;
-* Optimized Routing: currently just a Streamlit prototype, in the future shall be a more complete routing engine;
+* Accessible Routing: static distance, wheelchair, blind/low-vision, and
+  older/reduced-mobility routing profiles with directional precomputed grades;
+* Hazard Analysis: profile-specific screening from OSM kerb, tactile, surface,
+  cross-slope, barrier, and longitudinal-slope evidence;
 * Dashboard: featuring charts containing the bigger picture of the data;
 * Data Quality Tool: indexing possible errors in the data, mainly invalid values on tags, which are easy to find, but still errors;
-
-For the future, we are planning some additional ones, like:
-
 * Data Watcher: to monitor edits on data creating .rss feeds, which may have alerts if there are huge modifications, mainly deletions or possible vandalism;
-* Data Acquisition: listing projects ar platforms like Tasking Manager, MapRoulette, and Pic4Review to expand current data;
+* Data Hub and Acquisition: distributing node data and listing projects on
+  platforms such as Tasking Manager, MapRoulette, and Pic4Review.
+
+Routing and hazard terrain context uses the globally available Copernicus DEM
+2021 Cloud Optimized GeoTIFFs from the AWS Open Data Registry. GLO-30 is the
+preferred source and GLO-90 is the worldwide fallback. These are surface models
+used as contextual terrain evidence, not surveyed sidewalk or cross slope.

--- a/config.py
+++ b/config.py
@@ -103,3 +103,45 @@ other_footways_subcatecories = {
     "informal_footways": {"foot": ["yes", "permissive"]},
     "pedestrian_areas": {},  # defined only by geometry type (Polygon,Multipolygon)
 }
+
+
+# GLOBAL ELEVATION SOURCES
+#
+# Numeric OSM incline=* remains authoritative. Otherwise the routing and
+# hazard modules use the public Copernicus DEM Cloud Optimized GeoTIFFs hosted
+# by the AWS Open Data Registry. GLO-30 is preferred; GLO-90 guarantees global
+# land coverage where a public 30 m tile is unavailable. Both are digital
+# surface models, so derived values describe terrain context rather than a
+# surveyed sidewalk or cross slope.
+ELEVATION_CONFIG = {
+    "enabled": True,
+    "providers": [
+        {
+            "type": "copernicus_glo30",
+            "role": "global_primary",
+            "priority": 20,
+            "cache_dir": ".cache/oswm/elevation/copernicus_glo30",
+            "minimum_baseline_m": 45,
+            "sample_count": 7,
+            "max_abs_slope_percent": 40,
+        },
+        {
+            "type": "copernicus_glo90",
+            "role": "global_coverage_fallback",
+            "priority": 10,
+            "cache_dir": ".cache/oswm/elevation/copernicus_glo90",
+            "minimum_baseline_m": 135,
+            "sample_count": 7,
+            "max_abs_slope_percent": 40,
+        },
+    ],
+    "request_timeout_seconds": 120,
+}
+
+HAZARD_TERRAIN_CONFIG = {
+    "enabled": True,
+    "max_dimension": 1600,
+    # Suppress building-scale noise in the global surface model so the layer
+    # communicates broad terrain context.
+    "smoothing_sigma_pixels": 3.0,
+}

--- a/data/hazard_analysis/index.json
+++ b/data/hazard_analysis/index.json
@@ -1,0 +1,17 @@
+{
+    "folder": "data/hazard_analysis",
+    "files": [
+        "features_blind.geojson",
+        "features_elderly.geojson",
+        "features_pedestrian.geojson",
+        "features_wheelchair.geojson",
+        "metadata.json",
+        "profiles.json",
+        "terrain.json",
+        "terrain_blind.png",
+        "terrain_elderly.png",
+        "terrain_pedestrian.png",
+        "terrain_wheelchair.png"
+    ],
+    "subfolders": []
+}

--- a/data/hazard_analysis/metadata.json
+++ b/data/hazard_analysis/metadata.json
@@ -1,0 +1,130 @@
+{
+  "edge_kind_counts": {
+    "crossing": 2096,
+    "footway": 6620,
+    "sidewalk": 8134,
+    "stairs": 366
+  },
+  "feature_count": 17216,
+  "generated_at": "2026-07-30T16:07:22.056035+00:00",
+  "profile_audit": {
+    "blind": {
+      "most_common_decisive_rules": {
+        "barrier_steps": 312,
+        "crossing_tactile_no": 123,
+        "downhill_5_to_8_33": 2082,
+        "downhill_8_33_to_12_5": 1116,
+        "downhill_over_12_5": 684,
+        "smoothness_bad": 217,
+        "surface_cobble_sett": 869,
+        "surface_grass": 39,
+        "surface_gravel": 31,
+        "surface_ground_earth_dirt": 108
+      },
+      "severity_counts": {
+        "0": 11731,
+        "1": 2246,
+        "2": 2404,
+        "3": 822,
+        "4": 13
+      },
+      "status_counts": {
+        "hazard_detected": 5485,
+        "insufficient_data": 10960,
+        "no_detected_hazard": 771
+      }
+    },
+    "elderly": {
+      "most_common_decisive_rules": {
+        "barrier_steps": 312,
+        "downhill_5_to_8_33": 1096,
+        "downhill_8_33_to_12_5": 569,
+        "downhill_over_12_5": 329,
+        "kerb_raised": 193,
+        "smoothness_bad": 208,
+        "surface_cobble_sett": 780,
+        "uphill_5_to_8_33": 1132,
+        "uphill_8_33_to_12_5": 616,
+        "uphill_over_12_5": 355
+      },
+      "severity_counts": {
+        "0": 11671,
+        "1": 16,
+        "2": 3170,
+        "3": 1663,
+        "4": 696
+      },
+      "status_counts": {
+        "hazard_detected": 5545,
+        "insufficient_data": 10902,
+        "no_detected_hazard": 769
+      }
+    },
+    "pedestrian": {
+      "most_common_decisive_rules": {
+        "barrier_steps": 264,
+        "downhill_5_to_8_33": 1134,
+        "downhill_8_33_to_12_5": 569,
+        "downhill_over_12_5": 329,
+        "kerb_raised": 183,
+        "smoothness_bad": 208,
+        "surface_cobble_sett": 801,
+        "uphill_5_to_8_33": 1166,
+        "uphill_8_33_to_12_5": 616,
+        "uphill_over_12_5": 355
+      },
+      "severity_counts": {
+        "0": 11689,
+        "1": 3615,
+        "2": 1216,
+        "3": 691,
+        "4": 5
+      },
+      "status_counts": {
+        "hazard_detected": 5527,
+        "insufficient_data": 10916,
+        "no_detected_hazard": 773
+      }
+    },
+    "wheelchair": {
+      "most_common_decisive_rules": {
+        "barrier_steps": 369,
+        "downhill_5_to_8_33": 1018,
+        "downhill_8_33_to_12_5": 542,
+        "kerb_raised": 200,
+        "smoothness_bad": 110,
+        "surface_cobble_sett": 844,
+        "surface_ground_earth_dirt": 120,
+        "uphill_5_to_8_33": 1052,
+        "uphill_8_33_to_12_5": 583,
+        "uphill_over_12_5": 658
+      },
+      "severity_counts": {
+        "0": 11666,
+        "1": 0,
+        "2": 2173,
+        "3": 2142,
+        "4": 1235
+      },
+      "status_counts": {
+        "hazard_detected": 5550,
+        "insufficient_data": 10903,
+        "no_detected_hazard": 763
+      }
+    }
+  },
+  "ruleset_hash": "e92f5f0ebaaf33f5",
+  "ruleset_version": "0.1.0",
+  "schema_version": 1,
+  "slope_source_counts": {
+    "copernicus_glo30": 17201,
+    "copernicus_glo90": 2,
+    "direct_osm_numeric": 13
+  },
+  "warnings": [
+    "Hazard rules are provisional and require participatory calibration.",
+    "Missing evidence is never converted into a negative claim; unflagged does not mean safe.",
+    "Surface material is used only as a low-confidence proxy where direct smoothness evidence is unavailable.",
+    "Terrain rasters show unsigned contextual potential from a global DSM, never measured sidewalk or cross slope."
+  ]
+}

--- a/data/hazard_analysis/profiles.json
+++ b/data/hazard_analysis/profiles.json
@@ -1,0 +1,804 @@
+{
+  "categories": {
+    "barrier": {
+      "description": "Explicit or strongly inferred traversal barriers.",
+      "label": "Barrier"
+    },
+    "cross_slope": {
+      "description": "Only explicit OSM incline:across evidence.",
+      "label": "Cross slope"
+    },
+    "kerb": {
+      "description": "Kerb height/type and transition traversability.",
+      "label": "Kerb transition"
+    },
+    "longitudinal_slope": {
+      "description": "Directional terrain or explicitly mapped incline.",
+      "label": "Longitudinal slope"
+    },
+    "surface": {
+      "description": "Smoothness plus provisional surface-material proxies.",
+      "label": "Surface"
+    },
+    "tactile_orientation": {
+      "description": "Tactile evidence and detectable material transitions.",
+      "label": "Tactile and orientation"
+    }
+  },
+  "profiles": {
+    "blind": {
+      "description": "Detectable, orientable and predictable transitions.",
+      "label": "Blind or low-vision pedestrian"
+    },
+    "elderly": {
+      "description": "Stability, effort and fall-risk oriented assessment.",
+      "label": "Older or reduced-mobility pedestrian"
+    },
+    "pedestrian": {
+      "description": "General walking comfort and safety.",
+      "label": "Pedestrian"
+    },
+    "wheelchair": {
+      "description": "Continuous rollable access with manageable gradients.",
+      "label": "Wheelchair user"
+    }
+  },
+  "rules": [
+    {
+      "category": "barrier",
+      "confidence": 95,
+      "description": "Steps interrupt step-free movement.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Level change requires care",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "High effort and fall risk",
+          "severity": 3,
+          "traversability": "passable"
+        },
+        "pedestrian": {
+          "impact": "Additional effort",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Step-free passage blocked",
+          "severity": 4,
+          "traversability": "impassable"
+        }
+      },
+      "id": "barrier_steps"
+    },
+    {
+      "category": "barrier",
+      "confidence": 95,
+      "description": "OSM explicitly marks wheelchair access as unavailable.",
+      "directional": false,
+      "effects": {
+        "wheelchair": {
+          "impact": "Wheelchair access explicitly blocked",
+          "severity": 4,
+          "traversability": "impassable"
+        }
+      },
+      "id": "barrier_wheelchair_no"
+    },
+    {
+      "category": "barrier",
+      "confidence": 95,
+      "description": "OSM explicitly describes the surface as impassable.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Passage explicitly impassable",
+          "severity": 4,
+          "traversability": "impassable"
+        },
+        "elderly": {
+          "impact": "Passage explicitly impassable",
+          "severity": 4,
+          "traversability": "impassable"
+        },
+        "pedestrian": {
+          "impact": "Passage explicitly impassable",
+          "severity": 4,
+          "traversability": "impassable"
+        },
+        "wheelchair": {
+          "impact": "Passage explicitly impassable",
+          "severity": 4,
+          "traversability": "impassable"
+        }
+      },
+      "id": "surface_impassable"
+    },
+    {
+      "category": "kerb",
+      "confidence": 90,
+      "description": "A raised kerb is associated with the crossing.",
+      "directional": false,
+      "effects": {
+        "elderly": {
+          "impact": "Trip and fall hazard",
+          "severity": 3,
+          "traversability": "passable"
+        },
+        "pedestrian": {
+          "impact": "Abrupt level change",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Kerb blocks independent passage",
+          "severity": 4,
+          "traversability": "impassable"
+        }
+      },
+      "id": "kerb_raised"
+    },
+    {
+      "category": "kerb",
+      "confidence": 70,
+      "description": "A kerb is mapped without a traversable kerb type.",
+      "directional": false,
+      "effects": {
+        "elderly": {
+          "impact": "Potential abrupt level change",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Kerb traversability uncertain",
+          "severity": 3,
+          "traversability": "passable"
+        }
+      },
+      "id": "kerb_ambiguous_yes"
+    },
+    {
+      "category": "kerb",
+      "confidence": 85,
+      "description": "A rolled kerb can still require substantial effort.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Weakly defined transition",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "Unstable transition",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Difficult rolling transition",
+          "severity": 2,
+          "traversability": "passable"
+        }
+      },
+      "id": "kerb_rolled"
+    },
+    {
+      "category": "tactile_orientation",
+      "confidence": 95,
+      "description": "A flush kerb is explicitly paired with absent tactile paving.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Street boundary may be undetectable",
+          "severity": 4,
+          "traversability": "passable_with_extreme_risk"
+        },
+        "elderly": {
+          "impact": "Transition lacks tactile cue",
+          "severity": 1,
+          "traversability": "passable"
+        }
+      },
+      "id": "flush_without_tactile"
+    },
+    {
+      "category": "tactile_orientation",
+      "confidence": 90,
+      "description": "A lowered kerb is explicitly paired with absent tactile paving.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Street boundary has weak tactile detection",
+          "severity": 3,
+          "traversability": "passable"
+        }
+      },
+      "id": "lowered_without_tactile"
+    },
+    {
+      "category": "tactile_orientation",
+      "confidence": 90,
+      "description": "Tactile paving is explicitly absent at the crossing.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "No mapped tactile warning at street transition",
+          "severity": 3,
+          "traversability": "passable"
+        }
+      },
+      "id": "crossing_tactile_no"
+    },
+    {
+      "category": "tactile_orientation",
+      "confidence": 45,
+      "description": "Crossing, kerb and adjacent sidewalk share one explicitly mapped surface; this is a low-confidence detectability proxy.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Material transition may be difficult to detect",
+          "severity": 3,
+          "traversability": "passable"
+        }
+      },
+      "id": "uniform_transition_surface"
+    },
+    {
+      "category": "surface",
+      "confidence": 90,
+      "description": "Very horrible smoothness indicates an extreme unevenness.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Severe trip and orientation hazard",
+          "severity": 3,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "Extreme fall risk",
+          "severity": 4,
+          "traversability": "passable_with_extreme_risk"
+        },
+        "pedestrian": {
+          "impact": "Extreme unevenness",
+          "severity": 3,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Independent rolling may be impossible",
+          "severity": 4,
+          "traversability": "impassable"
+        }
+      },
+      "id": "smoothness_very_horrible"
+    },
+    {
+      "category": "surface",
+      "confidence": 90,
+      "description": "Horrible smoothness indicates severe unevenness.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Severe trip hazard",
+          "severity": 3,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "High fall risk",
+          "severity": 3,
+          "traversability": "passable"
+        },
+        "pedestrian": {
+          "impact": "Severe unevenness",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Rolling may be effectively blocked",
+          "severity": 4,
+          "traversability": "impassable"
+        }
+      },
+      "id": "smoothness_horrible"
+    },
+    {
+      "category": "surface",
+      "confidence": 90,
+      "description": "Very bad smoothness creates substantial mobility difficulty.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Substantial trip hazard",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "High instability",
+          "severity": 3,
+          "traversability": "passable"
+        },
+        "pedestrian": {
+          "impact": "Substantial unevenness",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Very difficult rolling surface",
+          "severity": 3,
+          "traversability": "passable"
+        }
+      },
+      "id": "smoothness_very_bad"
+    },
+    {
+      "category": "surface",
+      "confidence": 90,
+      "description": "Bad smoothness creates a meaningful mobility penalty.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Trip hazard",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "Instability and fall risk",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "pedestrian": {
+          "impact": "Uneven walking surface",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Difficult rolling surface",
+          "severity": 2,
+          "traversability": "passable"
+        }
+      },
+      "id": "smoothness_bad"
+    },
+    {
+      "category": "surface",
+      "confidence": 55,
+      "description": "Surface material is a provisional mobility proxy.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Unstable surface",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "High instability",
+          "severity": 3,
+          "traversability": "passable"
+        },
+        "pedestrian": {
+          "impact": "Loose surface",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Wheels may become immobilized",
+          "severity": 4,
+          "traversability": "impassable"
+        }
+      },
+      "id": "surface_sand"
+    },
+    {
+      "category": "surface",
+      "confidence": 55,
+      "description": "Surface material is a provisional mobility proxy.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Variable surface",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "Unstable footing",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "pedestrian": {
+          "impact": "Variable natural surface",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "High rolling resistance",
+          "severity": 3,
+          "traversability": "passable"
+        }
+      },
+      "id": "surface_grass"
+    },
+    {
+      "category": "surface",
+      "confidence": 55,
+      "description": "Surface material is a provisional mobility proxy.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Irregular surface",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "Unstable footing",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "pedestrian": {
+          "impact": "Weather-sensitive surface",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "High or variable rolling resistance",
+          "severity": 3,
+          "traversability": "passable"
+        }
+      },
+      "id": "surface_ground_earth_dirt"
+    },
+    {
+      "category": "surface",
+      "confidence": 55,
+      "description": "Surface material is a provisional mobility proxy.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Loose aggregate",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "Unstable footing",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "pedestrian": {
+          "impact": "Loose aggregate",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Difficult rolling surface",
+          "severity": 3,
+          "traversability": "passable"
+        }
+      },
+      "id": "surface_gravel"
+    },
+    {
+      "category": "surface",
+      "confidence": 55,
+      "description": "Surface material is a provisional mobility proxy.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Irregular trip-prone surface",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "Trip and instability hazard",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "pedestrian": {
+          "impact": "Uneven joints",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Difficult vibration-heavy rolling",
+          "severity": 3,
+          "traversability": "passable"
+        }
+      },
+      "id": "surface_cobble_sett"
+    },
+    {
+      "category": "surface",
+      "confidence": 50,
+      "description": "Surface material is a provisional mobility proxy.",
+      "directional": false,
+      "effects": {
+        "elderly": {
+          "impact": "Potentially loose footing",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Increased rolling resistance",
+          "severity": 2,
+          "traversability": "passable"
+        }
+      },
+      "id": "surface_compacted_fine_gravel"
+    },
+    {
+      "category": "cross_slope",
+      "confidence": 95,
+      "description": "Explicit cross slope exceeds 5%.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Strong lateral imbalance",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "High fall risk",
+          "severity": 3,
+          "traversability": "passable"
+        },
+        "pedestrian": {
+          "impact": "Strong lateral imbalance",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "High tip or drift risk",
+          "severity": 4,
+          "traversability": "passable_with_extreme_risk"
+        }
+      },
+      "id": "cross_slope_over_5"
+    },
+    {
+      "category": "cross_slope",
+      "confidence": 95,
+      "description": "Explicit cross slope is greater than 3% and at most 5%.",
+      "directional": false,
+      "effects": {
+        "blind": {
+          "impact": "Lateral imbalance",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "Instability",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "pedestrian": {
+          "impact": "Lateral imbalance",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Substantial drift or tip risk",
+          "severity": 3,
+          "traversability": "passable"
+        }
+      },
+      "id": "cross_slope_3_to_5"
+    },
+    {
+      "category": "cross_slope",
+      "confidence": 95,
+      "description": "Explicit cross slope is greater than 2% and at most 3%.",
+      "directional": false,
+      "effects": {
+        "elderly": {
+          "impact": "Mild lateral instability",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Noticeable lateral effort",
+          "severity": 2,
+          "traversability": "passable"
+        }
+      },
+      "id": "cross_slope_2_to_3"
+    },
+    {
+      "category": "longitudinal_slope",
+      "confidence": 80,
+      "description": "Travel direction rises by more than 12.5%.",
+      "directional": true,
+      "effects": {
+        "blind": {
+          "impact": "Extreme climbing effort",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "Extreme exertion and fall risk",
+          "severity": 4,
+          "traversability": "passable_with_extreme_risk"
+        },
+        "pedestrian": {
+          "impact": "Extreme climbing effort",
+          "severity": 3,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Independent ascent may be impossible",
+          "severity": 4,
+          "traversability": "impassable"
+        }
+      },
+      "id": "uphill_over_12_5"
+    },
+    {
+      "category": "longitudinal_slope",
+      "confidence": 80,
+      "description": "Travel direction rises by more than 8.33% and at most 12.5%.",
+      "directional": true,
+      "effects": {
+        "blind": {
+          "impact": "High climbing effort",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "High exertion",
+          "severity": 3,
+          "traversability": "passable"
+        },
+        "pedestrian": {
+          "impact": "High climbing effort",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Very difficult ascent",
+          "severity": 3,
+          "traversability": "passable"
+        }
+      },
+      "id": "uphill_8_33_to_12_5"
+    },
+    {
+      "category": "longitudinal_slope",
+      "confidence": 80,
+      "description": "Travel direction rises by more than 5% and at most 8.33%.",
+      "directional": true,
+      "effects": {
+        "elderly": {
+          "impact": "Increased exertion",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "pedestrian": {
+          "impact": "Increased climbing effort",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Difficult ascent",
+          "severity": 2,
+          "traversability": "passable"
+        }
+      },
+      "id": "uphill_5_to_8_33"
+    },
+    {
+      "category": "longitudinal_slope",
+      "confidence": 80,
+      "description": "Travel direction descends by more than 12.5%.",
+      "directional": true,
+      "effects": {
+        "blind": {
+          "impact": "Extreme descent hazard",
+          "severity": 3,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "Extreme fall risk",
+          "severity": 4,
+          "traversability": "passable_with_extreme_risk"
+        },
+        "pedestrian": {
+          "impact": "Extreme braking and fall risk",
+          "severity": 3,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Loss-of-control risk",
+          "severity": 4,
+          "traversability": "passable_with_extreme_risk"
+        }
+      },
+      "id": "downhill_over_12_5"
+    },
+    {
+      "category": "longitudinal_slope",
+      "confidence": 80,
+      "description": "Travel direction descends by more than 8.33% and at most 12.5%.",
+      "directional": true,
+      "effects": {
+        "blind": {
+          "impact": "Steep descent hazard",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "High fall risk",
+          "severity": 3,
+          "traversability": "passable"
+        },
+        "pedestrian": {
+          "impact": "High braking effort",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Substantial loss-of-control risk",
+          "severity": 3,
+          "traversability": "passable"
+        }
+      },
+      "id": "downhill_8_33_to_12_5"
+    },
+    {
+      "category": "longitudinal_slope",
+      "confidence": 80,
+      "description": "Travel direction descends by more than 5% and at most 8.33%.",
+      "directional": true,
+      "effects": {
+        "blind": {
+          "impact": "Increased descent care",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "elderly": {
+          "impact": "Increased fall risk",
+          "severity": 2,
+          "traversability": "passable"
+        },
+        "pedestrian": {
+          "impact": "Increased braking effort",
+          "severity": 1,
+          "traversability": "passable"
+        },
+        "wheelchair": {
+          "impact": "Difficult controlled descent",
+          "severity": 2,
+          "traversability": "passable"
+        }
+      },
+      "id": "downhill_5_to_8_33"
+    }
+  ],
+  "ruleset_hash": "e92f5f0ebaaf33f5",
+  "ruleset_version": "0.1.0",
+  "schema_version": 1,
+  "severity_levels": {
+    "0": {
+      "color": "#4daf4a",
+      "description": "No rule matched the available evidence.",
+      "label": "No detected hazard"
+    },
+    "1": {
+      "color": "#fee08b",
+      "description": "May reduce comfort or require additional effort.",
+      "label": "Uncomfortable"
+    },
+    "2": {
+      "color": "#fdae61",
+      "description": "Meaningfully degrades pedestrian accessibility.",
+      "label": "Unfavorable"
+    },
+    "3": {
+      "color": "#f46d43",
+      "description": "May create a serious safety or mobility hazard.",
+      "label": "Dangerous"
+    },
+    "4": {
+      "color": "#a50026",
+      "description": "Potential barrier or extreme contextual safety risk.",
+      "label": "Critical"
+    }
+  }
+}

--- a/data/hazard_analysis/terrain.json
+++ b/data/hazard_analysis/terrain.json
@@ -1,0 +1,82 @@
+{
+  "available": true,
+  "bounds": [
+    -49.3869938,
+    -25.6427063,
+    -49.1886809,
+    -25.3473833
+  ],
+  "coordinates": [
+    [
+      -49.3869938,
+      -25.3473833
+    ],
+    [
+      -49.1886809,
+      -25.3473833
+    ],
+    [
+      -49.1886809,
+      -25.6427063
+    ],
+    [
+      -49.3869938,
+      -25.6427063
+    ]
+  ],
+  "cross_slope_included": false,
+  "description": "Contextual unsigned slope potential derived from a global digital surface model. It is not a measurement of sidewalk or cross slope.",
+  "directionality": "unsigned contextual potential",
+  "generated_at": "2026-07-30T16:07:22.050608+00:00",
+  "height": 1063,
+  "license": "Copernicus DEM free licence",
+  "license_url": "https://dataspace.copernicus.eu/explore-data/data-collections/copernicus-contributing-missions/collections-description/COP-DEM",
+  "profiles": {
+    "blind": {
+      "path": "data/hazard_analysis/terrain_blind.png",
+      "thresholds_percent": [
+        5.0,
+        8.33,
+        12.5,
+        20.0
+      ]
+    },
+    "elderly": {
+      "path": "data/hazard_analysis/terrain_elderly.png",
+      "thresholds_percent": [
+        2.0,
+        5.0,
+        8.33,
+        12.5
+      ]
+    },
+    "pedestrian": {
+      "path": "data/hazard_analysis/terrain_pedestrian.png",
+      "thresholds_percent": [
+        5.0,
+        8.33,
+        12.5,
+        20.0
+      ]
+    },
+    "wheelchair": {
+      "path": "data/hazard_analysis/terrain_wheelchair.png",
+      "thresholds_percent": [
+        2.0,
+        5.0,
+        8.33,
+        12.5
+      ]
+    }
+  },
+  "provider_failures": [],
+  "resolution_m": 30,
+  "schema_version": 1,
+  "smoothing_sigma_pixels": 3.0,
+  "source_attribution": "Produced using Copernicus WorldDEM-30 © DLR e.V. 2010–2014 and © Airbus Defence and Space GmbH 2014–2018 provided under COPERNICUS by the European Union and ESA; all rights reserved.",
+  "source_name": "copernicus_glo30",
+  "source_title": "Copernicus DEM GLO-30 Public (2021)",
+  "source_url": "https://registry.opendata.aws/copernicus-dem/",
+  "title": "Terrain difficulty potential",
+  "width": 714
+}

--- a/data/index.json
+++ b/data/index.json
@@ -111,6 +111,23 @@
                 "profiles.json",
                 "slope_cache.json"
             ]
+        },
+        "hazard_analysis": {
+            "description": "Profile-specific pedestrian hazard evidence and global terrain-difficulty overlays.",
+            "path": "data/hazard_analysis",
+            "files": [
+                "features_blind.geojson",
+                "features_elderly.geojson",
+                "features_pedestrian.geojson",
+                "features_wheelchair.geojson",
+                "metadata.json",
+                "profiles.json",
+                "terrain.json",
+                "terrain_blind.png",
+                "terrain_elderly.png",
+                "terrain_pedestrian.png",
+                "terrain_wheelchair.png"
+            ]
         }
     }
 }

--- a/data/routing/metadata.json
+++ b/data/routing/metadata.json
@@ -5,75 +5,78 @@
     "sidewalk": 8134,
     "stairs": 366
   },
-  "elevation_provider_fingerprint": "afc75b33782b6cd5",
+  "elevation_provider_fingerprint": "a4a4bc7ab35d623e",
   "feature_count": 17216,
-  "generated_at": "2026-07-30T08:21:53.503827+00:00",
+  "generated_at": "2026-07-30T16:07:12.550049+00:00",
   "profile_audit": {
     "blind": {
       "grade_bands": {
         "0": 139,
         "1-19": 0,
         "20-39": 1963,
-        "40-59": 13872,
-        "60-79": 1233,
-        "80-100": 9
+        "40-59": 13595,
+        "60-79": 1405,
+        "80-100": 114
       },
-      "maximum_grade": 87,
-      "mean_grade": 46.66,
+      "maximum_grade": 96,
+      "mean_grade": 48.87,
       "minimum_grade": 0,
       "most_common_limiting_factors": {
         "barrier": 5,
         "crossing": 19,
-        "incline": 35,
-        "lighting": 103,
-        "smoothness": 3309,
-        "surface": 10489,
+        "incline": 653,
+        "lighting": 111,
+        "smoothness": 3162,
+        "surface": 10087,
         "tactile_paving": 2077,
-        "width": 1179
+        "width": 1102
       }
     },
     "elderly": {
       "grade_bands": {
-        "0": 8,
-        "1-19": 576,
-        "20-39": 1594,
-        "40-59": 15014,
-        "60-79": 24,
-        "80-100": 0
+        "0": 692,
+        "1-19": 512,
+        "20-39": 1510,
+        "40-59": 13630,
+        "60-79": 869,
+        "80-100": 3
       },
-      "maximum_grade": 66,
-      "mean_grade": 41.62,
+      "maximum_grade": 84,
+      "mean_grade": 44.54,
       "minimum_grade": 0,
       "most_common_limiting_factors": {
         "barrier": 5,
-        "crossing": 1562,
-        "incline": 37,
-        "kerb": 494,
-        "smoothness": 2812,
-        "surface": 11357,
-        "width": 949
+        "cross_slope": 18,
+        "crossing": 1382,
+        "incline": 1861,
+        "kerb": 454,
+        "lighting": 10,
+        "smoothness": 2544,
+        "surface": 10050,
+        "width": 892
       }
     },
     "wheelchair": {
       "grade_bands": {
-        "0": 606,
+        "0": 1224,
         "1-19": 7,
-        "20-39": 12242,
-        "40-59": 4356,
-        "60-79": 5,
+        "20-39": 1726,
+        "40-59": 14186,
+        "60-79": 73,
         "80-100": 0
       },
-      "maximum_grade": 61,
-      "mean_grade": 37.85,
+      "maximum_grade": 74,
+      "mean_grade": 39.97,
       "minimum_grade": 0,
       "most_common_limiting_factors": {
         "barrier": 403,
-        "crossing": 593,
-        "incline": 37,
-        "kerb": 1307,
-        "smoothness": 2763,
-        "surface": 11132,
-        "width": 981
+        "cross_slope": 30,
+        "crossing": 538,
+        "incline": 1738,
+        "kerb": 1158,
+        "smoothness": 2514,
+        "surface": 9916,
+        "width": 919
       }
     }
   },
@@ -81,12 +84,12 @@
   "ruleset_version": "1.1.0",
   "schema_version": 1,
   "slope_source_counts": {
-    "copernicus_glo30": 4,
-    "direct_osm_numeric": 13,
-    "missing": 17199
+    "copernicus_glo30": 17201,
+    "copernicus_glo90": 2,
+    "direct_osm_numeric": 13
   },
   "warnings": [
     "Profile rules are provisional and require participatory calibration.",
-    "Copernicus GLO-30 is a 30 m surface model; its slopes describe terrain trend, not measured sidewalk or cross slope."
+    "Global DEM providers describe terrain trend, not measured sidewalk or cross slope."
   ]
 }

--- a/hub/API/index.html
+++ b/hub/API/index.html
@@ -1651,6 +1651,94 @@ print(data)</pre>
     "deliverable": "map_data"
   },
   {
+    "category": "Pedestrian Hazard Analysis",
+    "path": "data/hazard_analysis/features_blind.geojson",
+    "format": "GeoJSON",
+    "description": "Blind/low-vision-profile hazard screening with directional evidence and category severities.",
+    "playground": true,
+    "deliverable": "map_data"
+  },
+  {
+    "category": "Pedestrian Hazard Analysis",
+    "path": "data/hazard_analysis/features_elderly.geojson",
+    "format": "GeoJSON",
+    "description": "Older/reduced-mobility-profile hazard screening with directional evidence and category severities.",
+    "playground": true,
+    "deliverable": "map_data"
+  },
+  {
+    "category": "Pedestrian Hazard Analysis",
+    "path": "data/hazard_analysis/features_pedestrian.geojson",
+    "format": "GeoJSON",
+    "description": "Pedestrian-profile hazard screening with directional evidence and category severities.",
+    "playground": true,
+    "deliverable": "map_data"
+  },
+  {
+    "category": "Pedestrian Hazard Analysis",
+    "path": "data/hazard_analysis/features_wheelchair.geojson",
+    "format": "GeoJSON",
+    "description": "Wheelchair-profile hazard screening with directional evidence and category severities.",
+    "playground": true,
+    "deliverable": "map_data"
+  },
+  {
+    "category": "Pedestrian Hazard Analysis",
+    "path": "data/hazard_analysis/metadata.json",
+    "format": "JSON",
+    "description": "Hazard generation audit, evidence caveats, severity counts, and elevation-source provenance.",
+    "playground": true,
+    "deliverable": "map_data"
+  },
+  {
+    "category": "Pedestrian Hazard Analysis",
+    "path": "data/hazard_analysis/profiles.json",
+    "format": "JSON",
+    "description": "Browser-safe hazard profiles, severity levels, categories, explanations, effects, and ruleset provenance.",
+    "playground": true,
+    "deliverable": "map_data"
+  },
+  {
+    "category": "Pedestrian Hazard Analysis",
+    "path": "data/hazard_analysis/terrain.json",
+    "format": "JSON",
+    "description": "Terrain overlay bounds, profile thresholds, global AWS DEM attribution, and availability status.",
+    "playground": true,
+    "deliverable": "map_data"
+  },
+  {
+    "category": "Pedestrian Hazard Analysis",
+    "path": "data/hazard_analysis/terrain_blind.png",
+    "format": "PNG",
+    "description": "Transparent blind/low-vision terrain-difficulty overlay derived from the configured global AWS DEM.",
+    "playground": false,
+    "deliverable": "map_data"
+  },
+  {
+    "category": "Pedestrian Hazard Analysis",
+    "path": "data/hazard_analysis/terrain_elderly.png",
+    "format": "PNG",
+    "description": "Transparent older/reduced-mobility terrain-difficulty overlay derived from the configured global AWS DEM.",
+    "playground": false,
+    "deliverable": "map_data"
+  },
+  {
+    "category": "Pedestrian Hazard Analysis",
+    "path": "data/hazard_analysis/terrain_pedestrian.png",
+    "format": "PNG",
+    "description": "Transparent pedestrian terrain-difficulty overlay derived from the configured global AWS DEM.",
+    "playground": false,
+    "deliverable": "map_data"
+  },
+  {
+    "category": "Pedestrian Hazard Analysis",
+    "path": "data/hazard_analysis/terrain_wheelchair.png",
+    "format": "PNG",
+    "description": "Transparent wheelchair terrain-difficulty overlay derived from the configured global AWS DEM.",
+    "playground": false,
+    "deliverable": "map_data"
+  },
+  {
     "category": "Routing & Demos",
     "path": "data/routing/demo.geojson",
     "format": "GeoJSON",
@@ -2119,6 +2207,14 @@ print(data)</pre>
     "path": "data/data_quality/index.json",
     "format": "JSON",
     "description": "Folder-level data index describing files and subdirectories available inside the 'data_quality' folder.",
+    "playground": true,
+    "deliverable": "map_data"
+  },
+  {
+    "category": "Folder Indexes",
+    "path": "data/hazard_analysis/index.json",
+    "format": "JSON",
+    "description": "Folder-level data index describing files and subdirectories available inside the 'hazard_analysis' folder.",
     "playground": true,
     "deliverable": "map_data"
   },

--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@
     <title>OSWM Node Home</title>
 
     <link rel="icon" type="image/x-icon"
-        href="https://kauevestena.github.io/oswm_codebase/assets/homepage/favicon_homepage.png">
+        href="oswm_codebase/assets/branding/favicon_homepage.png">
 
 
     <!-- Place this tag in your head or just before your close body tag. -->
@@ -263,7 +263,7 @@
         <div>
 
             <img title="OSWM Logo"
-                src="https://kauevestena.github.io/oswm_codebase/assets/homepage/project_logo_100px.png" alt="OSWM Logo"
+                src="oswm_codebase/assets/branding/logos/project_logo_100px.png" alt="OSWM Logo"
                 style="vertical-align:middle; height: 50;" id="logo_img">
 
             <div id="logo_text_div">
@@ -292,16 +292,15 @@
     </h3>
 
     <!--MODULES INSERTION POINT-->
-    
+
     <div class="media">
 
-
     <a href="map.html">
-        
-        <img title="OSWM webmap" 
-        src="oswm_codebase/assets/homepage/oswm_webmap_img.png" 
+
+        <img title="OSWM webmap"
+        src="oswm_codebase/assets/homepage/oswm_webmap_img.png"
         alt="OSWM webmap image" class="media_image responsive">
-    
+
         <!-- THX: https://jsfiddle.net/Venugopal/e0u4sow1/1/ -->
 
         <div class="media__body">
@@ -310,22 +309,20 @@
 
         </div>
 
-    </a> 
+    </a>
 
     </div>
     <p></p>
-        
-    
-    
+
+
     <div class="media">
 
-
     <a href="oswm_codebase/routing/routing_demo.html">
-        
-        <img title="OSWM routing" 
-        src="oswm_codebase/assets/homepage/oswm_route_img.png" 
+
+        <img title="OSWM routing"
+        src="oswm_codebase/assets/homepage/oswm_route_img.png"
         alt="OSWM routing image" class="media_image responsive">
-    
+
         <!-- THX: https://jsfiddle.net/Venugopal/e0u4sow1/1/ -->
 
         <div class="media__body">
@@ -334,22 +331,42 @@
 
         </div>
 
-    </a> 
+    </a>
 
     </div>
     <p></p>
-        
-    
-    
+
+
     <div class="media">
 
+    <a href="oswm_codebase/hazard_analysis/hazard_analysis.html">
+
+        <img title="OSWM hazard_analysis"
+        src="oswm_codebase/assets/homepage/oswm_hazard_img.svg"
+        alt="OSWM hazard_analysis image" class="media_image responsive">
+
+        <!-- THX: https://jsfiddle.net/Venugopal/e0u4sow1/1/ -->
+
+        <div class="media__body">
+
+            <h1>Hazard Analysis</h1>
+
+        </div>
+
+    </a>
+
+    </div>
+    <p></p>
+
+
+    <div class="media">
 
     <a href="statistics/index.html">
-        
-        <img title="OSWM dashboard" 
-        src="oswm_codebase/assets/homepage/oswm_statistics_img.png" 
+
+        <img title="OSWM dashboard"
+        src="oswm_codebase/assets/homepage/oswm_statistics_img.png"
         alt="OSWM dashboard image" class="media_image responsive">
-    
+
         <!-- THX: https://jsfiddle.net/Venugopal/e0u4sow1/1/ -->
 
         <div class="media__body">
@@ -358,22 +375,20 @@
 
         </div>
 
-    </a> 
+    </a>
 
     </div>
     <p></p>
-        
-    
-    
+
+
     <div class="media">
 
-
     <a href="quality_check/oswm_qc_main.html">
-        
-        <img title="OSWM data_quality" 
-        src="oswm_codebase/assets/homepage/oswm_quality_check_img.png" 
+
+        <img title="OSWM data_quality"
+        src="oswm_codebase/assets/homepage/oswm_quality_check_img.png"
         alt="OSWM data_quality image" class="media_image responsive">
-    
+
         <!-- THX: https://jsfiddle.net/Venugopal/e0u4sow1/1/ -->
 
         <div class="media__body">
@@ -382,22 +397,20 @@
 
         </div>
 
-    </a> 
+    </a>
 
     </div>
     <p></p>
-        
-    
-    
+
+
     <div class="media">
 
-
     <a href="hub/index.html">
-        
-        <img title="OSWM datahub" 
-        src="oswm_codebase/assets/homepage/oswm_datahub_img.png" 
+
+        <img title="OSWM datahub"
+        src="oswm_codebase/assets/homepage/oswm_datahub_img.png"
         alt="OSWM datahub image" class="media_image responsive">
-    
+
         <!-- THX: https://jsfiddle.net/Venugopal/e0u4sow1/1/ -->
 
         <div class="media__body">
@@ -406,12 +419,11 @@
 
         </div>
 
-    </a> 
+    </a>
 
     </div>
     <p></p>
-        
-    <!--MODULES INSERTION POINT-->
+<!--MODULES INSERTION POINT-->
 
 
 


### PR DESCRIPTION
## What changed

- enable the Hazard Analysis module in the node homepage, API, and generated data index
- configure AWS-hosted Copernicus DEM sources for global coverage: GLO-30 primary with GLO-90 fallback
- retain explicit OSM `incline=*` values as authoritative where present
- publish generated hazard profiles and terrain metadata for Curitiba
- point the `oswm_codebase` submodule at the implementation commit from kauevestena/oswm_codebase#9
- ignore large deployment artifacts and document the daily generation workflow

## Dependency

This PR depends on kauevestena/oswm_codebase#9. Merge the codebase PR first.

The submodule gitlink targets codebase commit `886f121069ddb26c6b246f9cd9cf109548d77ef3`.

## Validation

- 56 unit tests passed
- Python compilation, Bash syntax, JavaScript syntax, XML/SVG parsing, and `git diff --check` passed
- real Curitiba generation produced 17,216 features per hazard profile
- slope provenance: 17,201 AWS Copernicus GLO-30, 2 GLO-90 fallbacks, and 13 numeric OSM incline values
- module assets returned HTTP 200 in the local smoke test
- terrain rendering was visually inspected
- active configuration contains no TOPODATA dependency

## Generated cache note

`data/routing/slope_cache.json` is intentionally not committed here. It is a large derived cache and safely regenerates using the new provider fingerprint.