### PR TITLE
Document GitHub Pages bootstrap for new OSWM nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,36 @@ Routing and hazard terrain context uses the globally available Copernicus DEM
 2021 Cloud Optimized GeoTIFFs from the AWS Open Data Registry. GLO-30 is the
 preferred source and GLO-90 is the worldwide fallback. These are surface models
 used as contextual terrain evidence, not surveyed sidewalk or cross slope.
+
+## Creating a new node
+
+After creating a repository from this template, GitHub Pages must be enabled
+once before the included deployment workflow can publish the node.
+
+1. Open the new repository on GitHub.
+2. Go to **Settings → Pages**.
+3. Under **Build and deployment**, set **Source** to **GitHub Actions**.
+4. Do not create a suggested Pages workflow. This template already provides
+   `.github/workflows/deploy_pages.yml`.
+5. Run the node setup and data-generation workflows as instructed for the new
+   node. Then run `deploy_pages`, or push a generated site change that triggers
+   it.
+6. Confirm that the deployment succeeds and that the node is available at
+   `https://<owner>.github.io/<repository>/`.
+
+### Organization repositories
+
+An organization owner may first need to allow Pages publication:
+
+1. Open the organization **Settings**.
+2. Go to **Member privileges**.
+3. Under **Pages creation**, allow **Public** Pages sites and save.
+4. Return to the repository's **Settings → Pages** and select
+   **GitHub Actions**.
+
+This is a required one-time repository bootstrap step. A workflow's
+`GITHUB_TOKEN` may have `pages: write` permission but still be unable to
+create the Pages site for a new organization repository. In that case,
+`actions/configure-pages` fails with
+`Resource not accessible by integration`. Enable Pages in the repository
+settings, then rerun the failed deployment; no replacement workflow is needed.


### PR DESCRIPTION
## Summary

Documents the one-time GitHub Pages prerequisite for repositories created from the OSWM node template.

- select **GitHub Actions** under repository **Settings → Pages**
- retain the template's existing deployment workflow
- document the organization-level Pages publication permission
- explain the `Resource not accessible by integration` failure observed while establishing the Milan node
- include deployment and public-URL verification steps

No generated data or application code is changed.