### PR TITLE
Fix Curitiba codebase synchronization

### DIFF
--- a/.github/workflows/customizable.yml
+++ b/.github/workflows/customizable.yml
@@ -48,7 +48,7 @@ jobs:
       - run: pip install -r requirements.txt
 
       #### main ________________________________________________________________
-      - run: sh oswm_codebase/runners/custom.sh
+      - run: bash oswm_codebase/runners/custom.sh
   
       #### upload ______________________________________________________________
       # @see https://github.com/actions/checkout#push-a-commit-using-the-built-in-token

--- a/.github/workflows/data_daily_updating.yml
+++ b/.github/workflows/data_daily_updating.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Run daily job
         id: daily_job
         continue-on-error: true
-        run: sh oswm_codebase/runners/daily.sh
+        run: bash oswm_codebase/runners/daily.sh
 
       - name: Validate generated tiles
         id: validate_tiles

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -44,7 +44,7 @@ jobs:
       - run: pip install -r requirements.txt
 
       #### main ________________________________________________________________
-      - run: sh oswm_codebase/runners/setup.sh
+      - run: bash oswm_codebase/runners/setup.sh
 
       #### upload ______________________________________________________________
       # @see https://github.com/actions/checkout#push-a-commit-using-the-built-in-token

--- a/.github/workflows/update_codebase.yml
+++ b/.github/workflows/update_codebase.yml
@@ -1,6 +1,10 @@
 name: Synchronize oswm_codebase
 
 on:
+  # Safety net for missed GitHub App dispatches. Runs before the daily data job
+  # and exits as a no-op when the submodule already matches origin/main.
+  schedule:
+    - cron: "30 6 * * *"
   repository_dispatch:
     types: [oswm-codebase-update]
   workflow_dispatch:
@@ -115,7 +119,7 @@ jobs:
         continue-on-error: true
         env:
           OSWM_FORCE_REGEN: "1"
-        run: sh oswm_codebase/runners/daily.sh
+        run: bash oswm_codebase/runners/daily.sh
 
       - name: Validate generated core tiles
         id: validate

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run weekly job
         id: weekly_job
         continue-on-error: true
-        run: sh oswm_codebase/runners/weekly.sh
+        run: bash oswm_codebase/runners/weekly.sh
   
       #### upload ______________________________________________________________
       # @see https://github.com/actions/checkout#push-a-commit-using-the-built-in-token


### PR DESCRIPTION
## What this fixes

- advances the Curitiba node from `oswm_codebase` `42d1f4fe` (2026-08-05) to current `main` at `b016ba26`
- invokes Bash-based OSWM runners with `bash` instead of incompatible `/bin/sh`
- adds a daily 06:30 UTC synchronization safety net before the 07:30 UTC data workflow
- retains `repository_dispatch` for immediate GitHub App propagation and keeps no-op behavior when already current

## Root cause

The node received zero `repository_dispatch` events after the validated synchronization workflow was merged, while daily checkouts continued using the committed submodule gitlink. The node remained 52 codebase commits behind.

## Validation status

- Python syntax compilation passed for current `oswm_codebase`.
- Exact forced regeneration passed the old `/bin/sh` failure after changing runner invocation to Bash and proceeded through data acquisition/filtering.
- Local end-to-end validation could not complete because this execution environment cannot install the system GDAL CLI (`ogr2ogr`), which the GitHub workflow installs explicitly. Per OSWM policy, this is submitted as an intervention PR rather than pushed directly to `main`.

After merge, manually run **Synchronize oswm_codebase** once (or allow the 06:30 UTC schedule); it will regenerate, validate core PMTiles, commit generated outputs to `main`, and deploy Pages only on success.