### PR TITLE
Run codebase synchronization two hours before daily update

### DIFF
--- a/.github/workflows/update_codebase.yml
+++ b/.github/workflows/update_codebase.yml
@@ -1,10 +1,10 @@
 name: Synchronize oswm_codebase
 
 on:
-  # Safety net for missed GitHub App dispatches. Runs before the daily data job
-  # and exits as a no-op when the submodule already matches origin/main.
+  # Safety net for missed GitHub App dispatches. Runs at 05:30 UTC, two hours
+  # before the 07:30 UTC daily data job, and exits as a no-op when current.
   schedule:
-    - cron: "30 6 * * *"
+    - cron: "30 5 * * *"
   repository_dispatch:
     types: [oswm-codebase-update]
   workflow_dispatch:


### PR DESCRIPTION
Moves the scheduled `oswm_codebase` synchronization from 06:30 UTC to **05:30 UTC**, exactly two hours before the node's 07:30 UTC daily data update.

This gives delayed GitHub scheduled runs more time to finish while retaining:

- immediate `repository_dispatch` as the optional fast path;
- daily polling as the authentication-free guarantee;
- no-op behavior when the node already references current `oswm_codebase/main`.