### PR TITLE
Stop submodule updater from staging workflows

### DIFF
--- a/.github/workflows/update_codebase.yml
+++ b/.github/workflows/update_codebase.yml
@@ -26,9 +26,6 @@ jobs:
         with:
           fetch-depth: 0
           submodules: false
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
       - name: Check out the exact main-reachable core revision
         id: core
         env:
@@ -45,12 +42,13 @@ jobs:
           git -C oswm_codebase checkout --detach "$REVISION"
           REVISION="$(git -C oswm_codebase rev-parse HEAD)"
           echo "revision=$REVISION" >> "$GITHUB_OUTPUT"
-      - run: python oswm_codebase/special_updates.py
       - name: Commit the exact tested gitlink
         id: commit
         run: |
           echo "changed=false" >> "$GITHUB_OUTPUT"
-          git add -- oswm_codebase .github/workflows .oswm-managed-files.json
+          # Keep this job limited to the gitlink. GitHub's workflow token cannot
+          # push changes under .github/workflows; those are synchronized separately.
+          git add -- oswm_codebase
           if git diff --cached --quiet; then exit 0; fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Roll out the canonical submodule-updater write boundary: advance only the tested `oswm_codebase` gitlink. This prevents GitHub App workflow-permission rejection and dirty-tree rebases. Workflow synchronization remains a separate privileged operation.

No merge requested.